### PR TITLE
Add count, remove functionality to systems

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -14,6 +14,7 @@ func rhsmAPI() *rhsm.API {
 		api.AddResource("systemsList", systemsListResource())
 		api.AddResource("subscriptionList", subscriptionListResource())
 		api.AddResource("systemShow", systemsShowResource())
+		api.AddResource("systemRemove", systemRemoveResource())
 		api.AddResource("subSystemsList", subSystemResource())
 		api.AddResource("attachSub", attachSubResource())
 		api.AddResource("removeSub", removeSubResource())


### PR DESCRIPTION
This adds a couple flags to systems: `--count` and `--lastCheckinBefore`, which will show a plain count of systems filtered, and allow filtering by lastCheckin date, respectively.

It also adds the ability to unregister/remove systems, provided the same filtering abilities as with listing systems.